### PR TITLE
Clean up error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Ensure you have the following installed:
 - [Node.js](https://nodejs.org/) (version 20 or higher)
 - [npm](https://www.npmjs.com/)
 
+If you're using [nvm](https://github.com/nvm-sh/nvm/) (Node Version Manager), you can switch to the correct Node.js version by running:
+
+```sh
+nvm use
+```
+This will automatically use the Node.js version specified in the .nvmrc file.
+
 ### Installation
 
 1. Clone the repository:
@@ -35,4 +42,11 @@ Ensure you have the following installed:
 To start the development server, run:
 ```sh
 npm run dev
+```
+
+### Running Tests
+
+To run all tests, run:
+```sh
+npm run test
 ```

--- a/src/components/DevicesTable/index.jsx
+++ b/src/components/DevicesTable/index.jsx
@@ -53,12 +53,19 @@ const getIcon = (type) => {
 export const DevicesTable = () => {
     const [activeRow, setActiveRow] = useState(null)
     const { devices, formattedDevicesList } = useDevices()
-    const noDevicesMatchFilters = !formattedDevicesList.length && devices.length
+    const noDevicesMatchFilters = Boolean(!formattedDevicesList.length && devices.length)
+    const noDevices = !devices.length
+
   
     return (
         <div className="device-table" onMouseLeave={() => setActiveRow(null)}>
             <span>Device</span>
             <hr />
+            {noDevices &&
+                <span>
+                    No devices.
+                </span>
+            }
             {noDevicesMatchFilters &&
                 <span>
                     No devices match the selected filters.

--- a/src/components/DevicesTable/index.test.jsx
+++ b/src/components/DevicesTable/index.test.jsx
@@ -79,4 +79,15 @@ describe('DevicesTable', () => {
     expect(images[0]).toHaveAttribute('alt', 'Windows workstation');
     expect(images[1]).toHaveAttribute('alt', 'Mac workstation');
   });
+
+  test('displays no devices message when devices array is empty', async () => {
+    mockUseDevices.mockReturnValue({
+      devices: [],
+      formattedDevicesList: [],
+    });
+
+    await renderWithProviders(<DevicesTable />);
+    
+    expect(screen.getByText('No devices.')).toBeInTheDocument();
+  });
 });

--- a/src/contexts/DevicesContext.jsx
+++ b/src/contexts/DevicesContext.jsx
@@ -64,6 +64,7 @@ export function DevicesProvider({ children }) {
             setFormattedDevicesList(formattedDevices);
         } catch (error) {
             console.error(error);
+            console.error('Is the server running?');
         }
     }
 


### PR DESCRIPTION
Updates readme to let devs know they can use nvm

updates devices table with logic to handle when there are no devices

added log to check to make sure the server is running